### PR TITLE
feat: add Laravel 13 support

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -18,9 +18,13 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest]
         php: [8.3, 8.2]
-        laravel: [12.*, 11.*, 10.*]
+        laravel: [13.*, 12.*, 11.*, 10.*]
         stability: [prefer-lowest, prefer-stable]
         include:
+          - laravel: 13.*
+            testbench: 11.*
+            pest: ^4.0
+            pest_plugin: ^4.0
           - laravel: 12.*
             testbench: 10.*
             pest: ^3.8.2
@@ -34,6 +38,8 @@ jobs:
             pest: ^2.34.7
             pest_plugin: ^2.4
         exclude:
+          - laravel: 13.*
+            php: 8.2
           - laravel: 12.*
             php: 8.2
 

--- a/composer.json
+++ b/composer.json
@@ -20,15 +20,15 @@
     "require": {
         "php": "^8.2",
         "spatie/laravel-package-tools": "^1.16",
-        "illuminate/contracts": "^12.0||^11.0||^10.0"
+        "illuminate/contracts": "^13.0||^12.0||^11.0||^10.0"
     },
     "require-dev": {
         "laravel/pint": "^1.14",
         "nunomaduro/collision": "^8.1.1||^7.10.0||^8.0",
-        "orchestra/testbench": "^10.0||^9.0||^8.22.0",
-        "pestphp/pest": "^2.34.7||^3.8.2",
-        "pestphp/pest-plugin-arch": "^2.7||^3.0",
-        "pestphp/pest-plugin-laravel": "^2.3||^3.2"
+        "orchestra/testbench": "^11.0||^10.0||^9.0||^8.22.0",
+        "pestphp/pest": "^4.0||^3.8.2||^2.34.7",
+        "pestphp/pest-plugin-arch": "^4.0||^3.0||^2.7",
+        "pestphp/pest-plugin-laravel": "^4.0||^3.2||^2.3"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Add Laravel 13 Support

Added support for Laravel 13 by updating illuminate/contracts dependency
Updated dev dependencies to support Laravel 13
All tests passing with Laravel 13