### PR TITLE
Fix PHP code style workflow

### DIFF
--- a/.github/workflows/fix-php-code-style-issues.yml
+++ b/.github/workflows/fix-php-code-style-issues.yml
@@ -2,6 +2,8 @@ name: Fix PHP code style issues
 
 on:
   push:
+    branches:
+      - main
     paths:
       - '**.php'
 
@@ -16,8 +18,6 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v5
-        with:
-          ref: ${{ github.head_ref }}
 
       - name: Fix PHP code style issues
         uses: aglipanci/laravel-pint-action@2.6

--- a/database/seeders/BaseWorldSeeder.php
+++ b/database/seeders/BaseWorldSeeder.php
@@ -3,6 +3,7 @@
 namespace Altwaireb\World\Database\Seeders;
 
 use Altwaireb\World\Exceptions\InvalidCodeException;
+use Altwaireb\World\Exceptions\IsoCodesIsEmptyException;
 use Altwaireb\World\Models\City;
 use Altwaireb\World\Models\Country;
 use Altwaireb\World\Models\State;
@@ -16,7 +17,7 @@ class BaseWorldSeeder extends Seeder
     ) {}
 
     /**
-     * @throws \Altwaireb\World\Exceptions\IsoCodesIsEmptyException
+     * @throws IsoCodesIsEmptyException
      */
     public function run(): void
     {


### PR DESCRIPTION
## Summary

- Fix the PHP code style workflow so it only runs on pushes to `main`.
- Remove the use of `github.head_ref` from the push workflow.
- Apply the PHP code style fixes reported by Laravel Pint.

## Validation

- `vendor/bin/pint --test` passes.

## Notes

This is a separate maintenance fix following the `v1.2.0` release and does not modify the `v1.2.0` tag.